### PR TITLE
Freeze ruff version at or below 0.0.212

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ test_requires = [
     "pytest",
     "pytest-mock",
     "requests-mock",
-    "ruff",
+    "ruff>=0.0.188,<=0.0.212",
     "tox",
     "types-PyYAML",
     "types-requests",


### PR DESCRIPTION
Ruff is adding new lint checks quite quickly, which means newer versions of ruff can cause linting to fail.
This is a temporary solution until we have a more robust process for updating linting rules.